### PR TITLE
Add forge-notebook docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM jupyter/scipy-notebook
+
+LABEL maintainer="Ben Galewsky, National Data Service"
+
+USER root
+
+COPY ./ /forge/
+RUN chmod -R 777 /forge
+
+USER $NB_USER
+RUN cd /forge; \
+    pip install --user -e .
+
+CMD ["sh", "-c", "/forge/start-notebook-with-examples.sh --NotebookApp.token=${APP_TOKEN}"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,36 @@ cd forge
 pip install -e .
 ```
 
+### Jupyter Environment
+We use Docker to create a pre-built container for the
+[scipy Jupyter environment](https://hub.docker.com/r/jupyter/scipy-notebook/)
+along with Forge and required dependencies.
+
+To build a docker image
+```
+git clone https://github.com/materials-data-facility/forge.git
+cd forge
+docker build -t forge-notebook .
+docker run -it --rm -p 8888:8888 forge-notebook
+```
+
+Note that by default the docker image runs with no authentication. This is not
+recommended if the service is accessible from the internet. You can secure
+your service by generating a key:
+
+```
+% openssl rand -base64 32
+```
+
+And passing that key as an environment variable to the docker container:
+
+```
+% docker run -it --rm -e APP_TOKEN=yourtoken -p 8888:8888 forge-notebook
+```
+
+You can then visit http://localhost:8888 to launch a forge notebook. All of the
+examples from this repo can be found in the `work/examples` folder in Jupyter.
+
 # Examples
 
 ```python

--- a/start-notebook-with-examples.sh
+++ b/start-notebook-with-examples.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+if [ ! -d ~/work/examples ]; then
+   mkdir ~/work/examples
+   cp /forge/examples/*.ipynb ~/work/examples/
+fi
+
+. /usr/local/bin/start.sh jupyter notebook $*


### PR DESCRIPTION
# Problem
Running the forge tools requires installing some dependent libraries and using an integrated development environment. Trying out forge will be much easier under [Jupyter](http://jupyter.org), running inside a fully configured docker container.

#Approach 
The docker image is based on the `jupyter/scipy-notebook` notebook which comes with most of the useful scientific python packages installed. During docker image build time, it runs the `pip install` of forge.

For simplicity, the jupyter server comes up with no authentication enabled. If the image is deployed to a public server, a single docker environment variable, `APP_TOKEN` is provided to allow users to pass in a token which will be required to be entered in the browser.

# Testing
Check out this branch and follow the [README](https://github.com/BenGalewsky/forge/blob/forge-notebook_docker/README.md) section marked [Jupyter Environment](https://github.com/BenGalewsky/forge/blob/forge-notebook_docker/README.md#jupyter-environment).
 